### PR TITLE
リリース版でインジェクションが失敗する問題の修正

### DIFF
--- a/android/conf/proguard-triaina.txt
+++ b/android/conf/proguard-triaina.txt
@@ -1,5 +1,12 @@
 # Settings for triaina
 
+# modules are instantiated by reflection so make sure their
+# constructors don't get stripped:
+-keepclassmembers class * extends com.google.inject.Module {
+    <init> ();
+    <init> (android.content.Context);
+}
+
 -keep public class triaina.webview.DeviceBridgeProxy {
     public void notifyToDevice(java.lang.String);
 }


### PR DESCRIPTION
Since the injector construct module by reflection, Proguard may
remove these if they're not called explicitely anywhere else, which
would result in uninstantiable modules.
Make sure module constructors don't get shrunk by Proguard.
