### PR TITLE
FormFileが難読化されたいための修正

### DIFF
--- a/android/WebViewBridge/src/triaina/webview/entity/device/FormPictureSelectResult.java
+++ b/android/WebViewBridge/src/triaina/webview/entity/device/FormPictureSelectResult.java
@@ -44,7 +44,7 @@ public class FormPictureSelectResult implements Result {
 		return 0;
 	}
 	
-	public static class FormFile implements Parcelable {
+	public static class FormFile implements Result {
 		private String mId;
 		private String mFileName;
 		private String mThumbnail;


### PR DESCRIPTION
FormFile is returned to the web as part of FormPictureSelectResult, hence
it itself is a Result.
Since it will be converted to JSON as such, if not implementing Result it
will be missed by Proguard settings and be obfuscated (and the JSON keys
will be the obfuscated names instead of the original variable names...).
