### PR TITLE
Fix possible random NPE in AbstractWebViewBridgeFragment

### DIFF
--- a/android/WebViewBridge/src/triaina/webview/AbstractWebViewBridgeFragment.java
+++ b/android/WebViewBridge/src/triaina/webview/AbstractWebViewBridgeFragment.java
@@ -35,7 +35,6 @@ public abstract class AbstractWebViewBridgeFragment extends TriainaFragment {
     private TriainaEnvironment mEnvironment;
 
     private boolean mIsRestored;
-    private Bundle mWebViewStateOnDestroyView;
 
     final public String[] getDomains() {
         return mWebViewBridge.getDomainConfig().getDomains();
@@ -81,7 +80,6 @@ public abstract class AbstractWebViewBridgeFragment extends TriainaFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View inflatedView = mConfigurator.loadInflatedView(this, inflater, container);
         mWebViewBridge = mConfigurator.loadWebViewBridge(this, inflatedView);
-        mWebViewStateOnDestroyView = null;
         mConfigurator.configure(mWebViewBridge);
         mConfigurator.registerBridge(mWebViewBridge, this);
         configureSettings();
@@ -107,9 +105,6 @@ public abstract class AbstractWebViewBridgeFragment extends TriainaFragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        if (mWebViewStateOnDestroyView != null)
-            outState.putAll(mWebViewStateOnDestroyView);
-        // XXX
         if (mWebViewBridge != null)
             storeWebView(outState);
     }
@@ -132,8 +127,6 @@ public abstract class AbstractWebViewBridgeFragment extends TriainaFragment {
 
     @Override
     public void onDestroyView() {
-        mWebViewStateOnDestroyView = new Bundle();
-        storeWebView(mWebViewStateOnDestroyView);
         try {
             mWebViewBridge.destroy();
         } catch (Exception exp) {


### PR DESCRIPTION
- AbstractWebViewBridgeFragment.onDestroyView() calls WebView.destroy().
- AbstractWebViewBridgeFragment.onSaveInstanceState() calls
  WebView.saveState().
- WebView in at least Android 4.0 seems to throw NPE when saveState()
  called after destroy().
- onSaveInstanceState() is NOT guaranteed to be called before
  onDestroyView().
- Hense, random crash may occur.

Refer:
http://stackoverflow.com/questions/15313598/once-for-all-how-to-correctly-save-instance-state-of-fragments-in-back-stack

For reproducing WebView NPE bug, below code crashes with NPE in Android 4.0.3.
(activity_main.xml includes LinearLayout with android:id="@+id/hoge".)

``` java
package com.example.test;

import android.os.Bundle;
import android.app.Activity;
import android.view.Menu;
import android.view.ViewGroup;
import android.webkit.WebView;

public class MainActivity extends Activity {

    WebView mWebView;

    @Override
    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);
        mWebView = new WebView(this);
        mWebView.loadUrl("http://example.com/");
        ((ViewGroup) findViewById(R.id.hoge)).addView(mWebView);
    }

    @Override
    public void onBackPressed() {
        ((ViewGroup) findViewById(R.id.hoge)).removeView(mWebView);
        mWebView.destroy();
        mWebView.saveState(new Bundle());
    }
}
```
