### PR TITLE
update okhttp version

### DIFF
--- a/android/Commons/build.gradle
+++ b/android/Commons/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android-library'
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.squareup.okhttp:okhttp:2.4.0'
+    compile 'com.squareup.okhttp:okhttp:2.7.1'
 }
 
 android {


### PR DESCRIPTION
mixi connectの不具合で、mixiアプリのOkHttpバージョンを2.7.1に上げるので、triainaもそれに合わせます