### PR TITLE
無用な初期化をしない

### DIFF
--- a/ios/Triaina/TriainaWebViewAdapter.m
+++ b/ios/Triaina/TriainaWebViewAdapter.m
@@ -283,7 +283,7 @@
 
 - (void)webViewDidFinishLoad:(UIWebView *)aWebView
 {
-    if([self triainaAllowed]) {
+    if([self triainaAllowed] && aWebView.loading==NO) {
         if(self.consoleEnabled && !self.consoleInitialized)
             [self initializeConsole];
 


### PR DESCRIPTION
ページ内にiframeなどがあると、initialize*が何度も呼ばれてしまうので修正
