### PR TITLE
upgrade sdk version to api 22

### DIFF
--- a/android/Commons/build.gradle
+++ b/android/Commons/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
@@ -6,8 +6,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion "Google Inc.:Google APIs:16"
-    buildToolsVersion "19.1.0"
+    compileSdkVersion "Google Inc.:Google APIs:22"
+    buildToolsVersion "23.0.3"
 
     lintOptions {
         abortOnError false

--- a/android/Injector/build.gradle
+++ b/android/Injector/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 dependencies {
     // the exclude for 'android-support-v4.jar' is for Eclipse IDE compatibility,
@@ -15,8 +15,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion "Google Inc.:Google APIs:16"
-    buildToolsVersion "19.1.0"
+    compileSdkVersion "Google Inc.:Google APIs:22"
+    buildToolsVersion "23.0.3"
 
     sourceSets {
         main {

--- a/android/WebViewBridge/build.gradle
+++ b/android/WebViewBridge/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
@@ -8,8 +8,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion "Google Inc.:Google APIs:19"
-    buildToolsVersion "19.1.0"
+    compileSdkVersion "Google Inc.:Google APIs:22"
+    buildToolsVersion "23.0.3"
 
     lintOptions {
         abortOnError false

--- a/android/lib/HttpClientMultipart/build.gradle
+++ b/android/lib/HttpClientMultipart/build.gradle
@@ -1,12 +1,12 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
 }
 
 android {
-    compileSdkVersion "Google Inc.:Google APIs:16"
-    buildToolsVersion "19.1.0"
+    compileSdkVersion "Google Inc.:Google APIs:22"
+    buildToolsVersion "23.0.3"
 
     sourceSets {
         main {


### PR DESCRIPTION
Android Studio Instant Runを有効化するために、com.android.tools.build:gradle:2.0.0 を使いますが、compileSdkVersion Google Inc.:Google APIs:19 の解決ができないので、全て22に上げます